### PR TITLE
wrap main function if it doesn't exist

### DIFF
--- a/ob-rust.el
+++ b/ob-rust.el
@@ -76,24 +76,25 @@ This function is called by `org-babel-execute-src-block'."
          (_flags (cdr (assoc :flags processed-params)))
          (_args (cdr (assoc :args processed-params)))
          (coding-system-for-read 'utf-8) ;; use utf-8 with subprocesses
-         (coding-system-for-write 'utf-8))
-    (with-temp-file tmp-src-file (insert body))
+         (coding-system-for-write 'utf-8)
+         (wrapped-body (if (string-match-p "fn main()" body) body (concat "fn main() {\n" body "\n}"))))
+    (with-temp-file tmp-src-file (insert wrapped-body))
     (let ((results
-	   (org-babel-eval
-	    (format "cargo script %s" tmp-src-file)
+     (org-babel-eval
+      (format "cargo script %s" tmp-src-file)
             "")))
       (when results
         (org-babel-reassemble-table
          (if (or (member "table" (cdr (assoc :result-params processed-params)))
-	         (member "vector" (cdr (assoc :result-params processed-params))))
-	     (let ((tmp-file (org-babel-temp-file "rust-")))
-	       (with-temp-file tmp-file (insert (org-babel-trim results)))
-	       (org-babel-import-elisp-from-file tmp-file))
-	   (org-babel-read (org-babel-trim results) t))
+           (member "vector" (cdr (assoc :result-params processed-params))))
+       (let ((tmp-file (org-babel-temp-file "rust-")))
+         (with-temp-file tmp-file (insert (org-babel-trim results)))
+         (org-babel-import-elisp-from-file tmp-file))
+     (org-babel-read (org-babel-trim results) t))
          (org-babel-pick-name
-	  (cdr (assoc :colname-names params)) (cdr (assoc :colnames params)))
+    (cdr (assoc :colname-names params)) (cdr (assoc :colnames params)))
          (org-babel-pick-name
-	  (cdr (assoc :rowname-names params)) (cdr (assoc :rownames params))))))))
+    (cdr (assoc :rowname-names params)) (cdr (assoc :rownames params))))))))
 
 ;; This function should be used to assign any variables in params in
 ;; the context of the session environment.


### PR DESCRIPTION
Hi, 

I added simple wrapping with main function.
I don't like to type `fn main()` always.

Best Regards,
Changwoo.