### PR TITLE
Do not (require 'org)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   matrix:
     - EMACS=emacs23
     - EMACS=emacs24
+    - EMACS=emacs25
     - EMACS=emacs-snapshot
 
 matrix:
@@ -23,6 +24,12 @@ before_install:
       sudo apt-get -qq update &&
       sudo apt-get -qq -f install &&
       sudo apt-get -qq install emacs24 emacs24-el;
+    fi
+  - if [ "$EMACS" = "emacs25" ]; then
+      sudo add-apt-repository -y ppa:kelleyk/emacs &&
+      sudo apt-get -qq update &&
+      sudo apt-get -qq -f install &&
+      sudo apt-get -qq install emacs25;
     fi
   - if [ "$EMACS" = "emacs-snapshot" ]; then
       sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+
+language: rust
+cache: cargo
+
 env:
   matrix:
     - EMACS=emacs23
@@ -26,12 +30,17 @@ before_install:
       sudo apt-get -qq -f install &&
       sudo apt-get -qq install emacs-snapshot emacs-snapshot-el;
     fi
-
-before_script:
+  - if cargo install --list | grep '^cargo-script ' >/dev/null; then
+      true;
+    else
+      cargo install cargo-script;
+    fi
   - if [ "$EMACS" = "emacs23" ]; then
       curl 'http://orgmode.org/org-8.2.5h.tar.gz' \
           | tar xzf - --wildcards --strip-components=2 org-8.2.5h/lisp/*.el &&
       curl 'http://git.savannah.gnu.org/cgit/emacs.git/plain/lisp/emacs-lisp/ert.el?h=emacs-24.3' > ert.el;
     fi
+
+install: true
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
       sudo apt-get -qq -f install &&
       sudo apt-get -qq install emacs25;
     fi
-    fi
   - if cargo install --list | grep '^cargo-script ' >/dev/null; then
       true;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ env:
     - EMACS=emacs23
     - EMACS=emacs24
     - EMACS=emacs25
-    - EMACS=emacs-snapshot
-
-matrix:
-  allow_failures:
-    - env: EMACS=emacs-snapshot
 
 before_install:
   - if [ "$EMACS"= "emacs23" ]; then
@@ -31,11 +26,6 @@ before_install:
       sudo apt-get -qq -f install &&
       sudo apt-get -qq install emacs25;
     fi
-  - if [ "$EMACS" = "emacs-snapshot" ]; then
-      sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
-      sudo apt-get -qq update &&
-      sudo apt-get -qq -f install &&
-      sudo apt-get -qq install emacs-snapshot emacs-snapshot-el;
     fi
   - if cargo install --list | grep '^cargo-script ' >/dev/null; then
       true;

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,8 @@
 
 test:
 	@rm -f .test-org-id-locations
-	emacs -Q --batch -q \
-		-L . \
-		-l ob-rust.el \
-		-l test-ob-rust.el \
-		--eval "(progn \
-	              (setq org-confirm-babel-evaluate nil) \
-	              (org-babel-do-load-languages \
-	                'org-babel-load-languages '((emacs-lisp . t) \
-	                                            (rust . t))))" \
-	    -f ob-rust-test-runall
+	emacs -Q --batch \
+	      -L . \
+	      -l ert \
+	      -l test-ob-rust.el \
+	      -f ert-run-tests-batch-and-exit

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,5 @@ test:
 	              (setq org-confirm-babel-evaluate nil) \
 	              (org-babel-do-load-languages \
 	                'org-babel-load-languages '((emacs-lisp . t) \
-	                                            (sh . t) \
-	                                            (org . t) \
 	                                            (rust . t))))" \
 	    -f ob-rust-test-runall

--- a/ob-rust.el
+++ b/ob-rust.el
@@ -62,6 +62,7 @@
 
 
 ;; optionally define a file extension for this language
+(defvar org-babel-tangle-lang-exts)
 (add-to-list 'org-babel-tangle-lang-exts '("rust" . "rs"))
 
 (defvar org-babel-default-header-args:rust '())

--- a/ob-rust.el
+++ b/ob-rust.el
@@ -56,7 +56,6 @@
 ;;; TODO:
 
 ;;; Code:
-(require 'org)
 (require 'ob)
 (require 'ob-eval)
 (require 'ob-ref)

--- a/test-ob-rust.el
+++ b/test-ob-rust.el
@@ -66,4 +66,12 @@
       (org-babel-next-src-block)
       (should (string-equal "hello,ob-rust" (org-babel-execute-src-block))))))
 
+(ert-deftest ob-rust/wrap-main ()
+  "Test wrapping Rust code block in main function."
+  (let (org-confirm-babel-evaluate)
+    (ob-rust-test-update-id-locations)
+    (org-test-at-id "5947c402da07c7aca0000002"
+      (org-babel-next-src-block)
+      (should (string-equal "hello,ob-rust" (org-babel-execute-src-block))))))
+
 (provide 'ob-rust-test)

--- a/test-ob-rust.el
+++ b/test-ob-rust.el
@@ -64,7 +64,7 @@
   "Test the usage of string variables."
   (if (executable-find org-babel-rust-command)
       (org-test-at-id "5947c402da07c7aca0000001"
-		      (org-babel-next-src-block 6)
+		      (org-babel-next-src-block)
 		      (should (string-equal "hello,ob-rust" (org-babel-execute-src-block))))))
 
 (defun ob-rust-test-runall ()

--- a/test-ob-rust.el
+++ b/test-ob-rust.el
@@ -1,4 +1,4 @@
-;;; test-ob-go.el --- tests for ob-go.el
+;;; test-ob-rust.el --- tests for ob-rust.el
 
 ;; This file is not part of GNU Emacs.
 
@@ -17,7 +17,9 @@
 
 ;;; Code:
 (require 'ert)
+(require 'org)
 (require 'org-id)
+(require 'ob-rust)
 
 (defconst ob-rust-test-dir
   (expand-file-name (file-name-directory (or load-file-name buffer-file-name))))
@@ -53,23 +55,15 @@
 	 (kill-buffer to-be-removed)))))
 (def-edebug-spec org-test-at-id (form body))
 
-(unless (featurep 'ob-rust)
-  (signal 'missing-test-dependency "Support for Rust code blocks"))
-
 (ert-deftest ob-rust/assert ()
   (should t))
 
-
 (ert-deftest ob-rust/basic ()
   "Test the usage of string variables."
-  (if (executable-find org-babel-rust-command)
-      (org-test-at-id "5947c402da07c7aca0000001"
-		      (org-babel-next-src-block)
-		      (should (string-equal "hello,ob-rust" (org-babel-execute-src-block))))))
-
-(defun ob-rust-test-runall ()
-  (progn
+  (let (org-confirm-babel-evaluate)
     (ob-rust-test-update-id-locations)
-    (ert t)))
+    (org-test-at-id "5947c402da07c7aca0000001"
+      (org-babel-next-src-block)
+      (should (string-equal "hello,ob-rust" (org-babel-execute-src-block))))))
 
 (provide 'ob-rust-test)

--- a/test-ob-rust.org
+++ b/test-ob-rust.org
@@ -9,3 +9,12 @@ fn main() {
     println!("hello,ob-rust")
 }
 #+END_SRC
+
+* Wrapping main
+  :PROPERTIES:
+  :ID:       5947c402da07c7aca0000002
+  :END:
+#+source: basic
+#+BEGIN_SRC rust :results silent
+println!("hello,ob-rust")
+#+END_SRC


### PR DESCRIPTION
For me, requiring `org` leads to a "Recursive require for feature" error when ob-rust.el is required via `org-babel-load-languages` as the manual [suggests](https://orgmode.org/manual/Languages.html). As a minimal example:
```bash
$ ls .
init.el  ob-rust.el
$ cat init.el
(setq org-babel-load-languages '((emacs-lisp . t)
                                 (rust . t)))
(add-to-list 'load-path ".")
(require 'org)
$ emacs -Q --batch -l init.el
Recursive ‘require’ for feature ‘org’
$ emacs --version | head -1
GNU Emacs 26.1
```
For the same effect, `(setq ...` may be replaced with an M-x customized variable such as in the following:
```elisp
(custom-set-variables
'(org-babel-load-languages
  (quote
   ((rust . t)
    (emacs-lisp . t)))))
``` 
I guess `org` should not be required from an ob-*.el file. Compare with e.g. [lisp/org/ob-C.el](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/org/ob-C.el?h=emacs-26.1). This PR removes it.

Best regards,