### PR TITLE
Use rust-script instead of cargo-script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ before_install:
       sudo apt-get -qq -f install &&
       sudo apt-get -qq install emacs25;
     fi
-  - if cargo install --list | grep '^cargo-script ' >/dev/null; then
+  - if cargo install --list | grep '^rust-script ' >/dev/null; then
       true;
     else
-      cargo install cargo-script;
+      cargo install rust-script;
     fi
   - if [ "$EMACS" = "emacs23" ]; then
       curl 'http://orgmode.org/org-8.2.5h.tar.gz' \

--- a/README.org
+++ b/README.org
@@ -58,11 +58,11 @@ for more details or other methods installation, please visit: [[https://www.rust
 
 ** cargo script
 
-You can install [[https://github.com/DanielKeep/cargo-script][cargo-script]] using Cargo's install subcommand:
+You can install [[https://github.com/fornwall/rust-script][rust-script]] using Cargo's install subcommand:
 #+BEGIN_SRC sh
-cargo install cargo-script
+cargo install rust-script
 #+END_SRC
 
 * TODOs
 
-+ replace =cargo script= with =rustc= and run binary.
++ replace =rust-script= with =rustc= and run binary.

--- a/ob-rust.el
+++ b/ob-rust.el
@@ -47,7 +47,7 @@
 ;; - You must have rust and cargo installed and the rust and cargo should be in your `exec-path'
 ;;   rust command.
 ;;
-;; - cargo-script
+;; - rust-script
 ;;
 ;; - `rust-mode' is also recommended for syntax highlighting and
 ;;   formatting.  Not this particularly needs it, it just assumes you
@@ -81,7 +81,7 @@ This function is called by `org-babel-execute-src-block'."
     (with-temp-file tmp-src-file (insert wrapped-body))
     (let ((results
      (org-babel-eval
-      (format "cargo script %s" tmp-src-file)
+      (format "rust-script %s" tmp-src-file)
             "")))
       (when results
         (org-babel-reassemble-table


### PR DESCRIPTION
cargo-script no longer compiles on stable rust (1.47.0), and has not been
updated since October, 2017. [rust-script ](https://github.com/fornwall/rust-script) is a maintained fork of cargo-script.

https://github.com/DanielKeep/cargo-script/issues/71