### PR TITLE
Use a temporary ID location file for testing

### DIFF
--- a/test-ob-rust.el
+++ b/test-ob-rust.el
@@ -25,7 +25,7 @@
   (expand-file-name (file-name-directory (or load-file-name buffer-file-name))))
 
 (defconst org-id-locations-file
-  (expand-file-name ".test-org-id-locations" ob-rust-test-dir))
+  (org-babel-temp-file "test-org-id-locations-"))
 
 (defun ob-rust-test-update-id-locations ()
   (let ((files (directory-files


### PR DESCRIPTION
Use a temporary file for testing, so it doesn't set the location for the current session.

Closes #12