### PR TITLE
Use rustc instead of rust-script

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,14 +55,3 @@ curl https://sh.rustup.rs -sSf | sh
 #+END_SRC
 
 for more details or other methods installation, please visit: [[https://www.rust-lang.org/en-US/install.html][https://www.rust-lang.org/en-US/install.html]]
-
-** cargo script
-
-You can install [[https://github.com/fornwall/rust-script][rust-script]] using Cargo's install subcommand:
-#+BEGIN_SRC sh
-cargo install rust-script
-#+END_SRC
-
-* TODOs
-
-+ replace =rust-script= with =rustc= and run binary.

--- a/ob-rust.el
+++ b/ob-rust.el
@@ -47,8 +47,6 @@
 ;; - You must have rust and cargo installed and the rust and cargo should be in your `exec-path'
 ;;   rust command.
 ;;
-;; - rust-script
-;;
 ;; - `rust-mode' is also recommended for syntax highlighting and
 ;;   formatting.  Not this particularly needs it, it just assumes you
 ;;   have it.
@@ -81,7 +79,7 @@ This function is called by `org-babel-execute-src-block'."
     (with-temp-file tmp-src-file (insert wrapped-body))
     (let ((results
      (org-babel-eval
-      (format "rust-script %s -- %s %s" _flags tmp-src-file _args)
+      (format "rustc %s -- %s %s && chmod +x %s && %s" _flags tmp-src-file _args tmp-src-file tmp-src-file)
             "")))
       (when results
         (org-babel-reassemble-table


### PR DESCRIPTION
Compile the temp file with `rustc` instead.

It doesn't work yet:
![rustc](https://github.com/user-attachments/assets/40609e3e-d0fe-4051-ace5-18920abbd71c)

But I'll leave this here so anyone can suggest a fix.